### PR TITLE
FWMT-620 dont use hardcoded rabbit host

### DIFF
--- a/src/main/java/uk/gov/ons/fwmt/service_mocks/resource_service/controller/QueueController.java
+++ b/src/main/java/uk/gov/ons/fwmt/service_mocks/resource_service/controller/QueueController.java
@@ -87,7 +87,7 @@ public class QueueController {
     Channel channel = null;
     try {
       ConnectionFactory factory = new ConnectionFactory();
-      factory.setHost("localhost");
+      factory.setHost(rabbitHost);
       connection = factory.newConnection();
       channel = connection.createChannel();
 


### PR DESCRIPTION
previously the rabbit host had been hardcoded to localhost when creating the connection factory this caused problems when running through docker